### PR TITLE
Direct archetype insertion

### DIFF
--- a/ECSLib/Archetypes/ArchetypeManager.cs
+++ b/ECSLib/Archetypes/ArchetypeManager.cs
@@ -108,6 +108,23 @@ internal partial class ArchetypeManager
         _entitiesRecords.Add(entity, record);
         _archetypeIndexToEntities[0].Add(entity);
     }
+
+    /// <summary>
+    /// Registers an entity to the archetype storage with the provided archetype.
+    /// </summary>
+    /// <remarks>
+    /// <b>
+    /// WARNING: You MUST initialize components manually using <see cref="SetComponent{TComponent}"/>.
+    /// </b>
+    /// </remarks>
+    public void RegisterEntityInArchetype(Entity entity, IEnumerable<Type> archetype)
+    {
+        var archetypeIndex = GetOrCreateArchetype(archetype);
+        int indexInComponentSet = RegisterNewEntityForArchetype(archetypeIndex);
+        ArchetypeRecord record = new(archetypeIndex, indexInComponentSet);
+        _entitiesRecords.Add(entity, record);
+        _archetypeIndexToEntities[archetypeIndex].Add(entity);
+    }
     
     /// <summary>
     /// Changes the archetype of an entity, copying its components
@@ -214,6 +231,14 @@ internal partial class ArchetypeManager
         }
         return ref _archetypes[record.ArchetypeIndex].Components.Get<TComponent>(record.EntityIndexInArchetype);
     }
+
+    /// <summary>
+    /// Replaces the value of a component in an entity.<br/>
+    /// Equivalent to <see cref="GetComponent{TComponent}"/> = <see cref="value"/>;
+    /// </summary>
+    public void SetComponent<TComponent>(Entity entity, TComponent value) where TComponent : struct =>
+        GetComponent<TComponent>(entity) = value;
+
     #endregion
     
     #region QUERYING

--- a/ECSLib/ECS.cs
+++ b/ECSLib/ECS.cs
@@ -50,6 +50,16 @@ public sealed partial class ECS
         _archetypeManager.RegisterEmptyEntity(entity);
         return entity;
     }
+
+    /// <summary>Registers a new entity with the defined components.</summary>
+    /// <remarks><inheritdoc cref="ArchetypeManager.RegisterEntityInArchetype" path="remarks"/></remarks>
+    /// <returns> The new entity. </returns>
+    public Entity CreateEntityWithComponents(IEnumerable<Type> components)
+    {
+        var entity = _entityManager.CreateEntity();
+        _archetypeManager.RegisterEntityInArchetype(entity, components);
+        return entity;
+    }
     
     /// <summary> Unregisters an entity and all of its components. </summary>
     public void DestroyEntity(Entity entity)
@@ -88,6 +98,12 @@ public sealed partial class ECS
     public void RemoveComponent<TComponent>(Entity entity) where TComponent : struct
     {
         _archetypeManager.RemoveComponent<TComponent>(entity);
+    }
+
+    /// <inheritdoc cref="ArchetypeManager.SetComponent{TComponent}"/>
+    public void SetComponent<TComponent>(Entity entity, TComponent value) where TComponent : struct
+    {
+        _archetypeManager.SetComponent(entity, value);
     }
 
     #endregion


### PR DESCRIPTION
Methods used by XML deserialization to insert entities directly into the target archetype without copying excessively while going from archetype to archetype.

Closes #15 